### PR TITLE
End of Session notif should navigate to Session History

### DIFF
--- a/src/utils/Utils.tsx
+++ b/src/utils/Utils.tsx
@@ -49,7 +49,7 @@ export default class Utils {
     // Check
     if (typeof value === 'string') {
       // Create Object
-      changedValue = Utils.convertToInt(value);
+      changedValue = parseInt(value);
     }
     return changedValue;
   }

--- a/src/utils/Utils.tsx
+++ b/src/utils/Utils.tsx
@@ -49,7 +49,7 @@ export default class Utils {
     // Check
     if (typeof value === 'string') {
       // Create Object
-      changedValue = parseInt(value);
+      changedValue = parseInt(value, 10);
     }
     return changedValue;
   }


### PR DESCRIPTION
This navigation use Utils.convertToInt to get the transaction ID. 
This util function was recursive in the case where its parameter is a string.
This was the case for this navigation.
Now we use parseInt function in this case.